### PR TITLE
style(Hero): remove unnecessary padding from the name container for a…

### DIFF
--- a/src/components/brutalist/Hero.tsx
+++ b/src/components/brutalist/Hero.tsx
@@ -36,7 +36,7 @@ const Hero: React.FC<HeroProps> = ({ personalInfo, visitorCount, onVisitorClick 
 
       <div className="z-10 flex flex-col items-center justify-center space-y-8 w-full max-w-5xl">
         {/* Name with Brutalist Frame */}
-        <div className="border-8 border-black p-6  bg-white shadow-[12px_12px_0px_0px_rgba(0,0,0,1)] hover:shadow-none transition-all duration-200 cursor-default">
+        <div className="border-8 border-black bg-white shadow-[12px_12px_0px_0px_rgba(0,0,0,1)] hover:shadow-none transition-all duration-200 cursor-default">
           <Typography variant="serif" size="giant" className="glitch-text">
             {personalInfo.name}
           </Typography>


### PR DESCRIPTION
… cleaner brutalist design

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that adjusts spacing in the `Hero` component with no logic or data-flow impact.
> 
> **Overview**
> Removes the extra `p-6` padding from the hero name frame in `Hero.tsx` to tighten spacing and better match the brutalist design.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 117c37498f3c1477e68ea30f93fe933bca1c1745. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->